### PR TITLE
Update page on media types

### DIFF
--- a/docs/specification/index.md
+++ b/docs/specification/index.md
@@ -6,8 +6,10 @@
 
 See the specification pages for more details:
 
-- [Serialization format specification](serialization.md)
-- [gRPC streaming protocol specification](streaming.md)
-- [Protobuf reference](reference.md)
-- [Protobuf sources](protobuf-source.md)
-- [File extension and media type](media-type.md)
+- Specification documents:
+    - [Serialization format specification](serialization.md)
+    - [gRPC streaming protocol specification](streaming.md)
+- Protobuf definitions:
+    - [Protobuf reference](reference.md)
+    - [Protobuf sources](protobuf-source.md)
+- [File extensions and media types](media-type.md)

--- a/docs/specification/media-type.md
+++ b/docs/specification/media-type.md
@@ -1,9 +1,10 @@
-# File extension and media type
+# File extensions and media types
 
-Jelly is not tied to any specific file extension and does not have a registered media type. However, you can use the following:
+We recommend using these file extensions and media types when working with Jelly:
 
-- File extension: `.jelly`
-- Media type: `application/x-jelly-rdf`
+| | File extension | Media type |
+| --- | --- | --- |
+| [Jelly RDF serialization](serialization.md) | `.jelly` | `application/x-jelly-rdf` |
 
 The files should be saved in the [delimited variant of Jelly](serialization.md#delimited-variant-of-jelly).
 

--- a/docs/specification/media-type.md
+++ b/docs/specification/media-type.md
@@ -2,9 +2,9 @@
 
 We recommend using these file extensions and media types when working with Jelly:
 
-| | File extension | Media type |
+| Format | File extension | Media type |
 | --- | --- | --- |
-| [Jelly RDF serialization](serialization.md) | `.jelly` | `application/x-jelly-rdf` |
+| **[Jelly RDF serialization](serialization.md)** | `.jelly` | `application/x-jelly-rdf` |
 
 The files should be saved in the [delimited variant of Jelly](serialization.md#delimited-variant-of-jelly).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,7 +97,7 @@ nav:
     - gRPC streaming protocol: 'specification/streaming.md'
     - Protobuf reference: 'specification/reference.md'
     - Protobuf source: 'specification/protobuf-source.md'
-    - File extension and media type: 'specification/media-type.md'
+    - File extensions and media types: 'specification/media-type.md'
 
   - JVM (Scala) implementation ⮺: 'https://w3id.org/jelly/jelly-jvm/'
 


### PR DESCRIPTION
Made the page more general, to accomodate for future new specs based on the Jelly RDF serialization format (for example Jelly RDF Patch: https://github.com/Jelly-RDF/jelly-protobuf/issues/11 ). Made the language consistent with the spec ("recommended" extension and media type).