### PR TITLE
Add link to Jelly/RIOT docs, update ref to RDF-STaX

### DIFF
--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -10,7 +10,7 @@
     - This is implemented in the [ci-worker](https://github.com/RiverBench/ci-worker) application – a Scala 3 program making heavy use of [Jelly-JVM's]({{ jvm_link() }}) streaming capabilities.
 - [Jelly-JVM benchmark code](https://github.com/Jelly-RDF/jvm-benchmarks). This code was used to produce the results seen on the [performance page](performance/index.md).
 - [RDF Stream Taxonomy (RDF-STaX)](https://w3id.org/stax) uses Jelly for distributing the RDF-STaX ontology and the living literature review of RDF streaming.
-    - This is implemented using Apache Jena's RIOT command-line utility and [Jelly-JVM's Jena plugin]({{ jvm_link('getting-started-plugins') }}). Source code: [GitHub](https://github.com/RDF-STaX/ci-worker).
+    - This is implemented using [Apache Jena's RIOT command-line utility]({{ jvm_link('user/jena-cli') }}) and [Jelly-JVM's Jena plugin]({{ jvm_link('getting-started-plugins') }}). Source code: [GitHub](https://github.com/RDF-STaX/ci-worker).
 - *Not released publicly yet – stay tuned!* A Scala 2 application using Jelly over Kafka, MQTT, and gRPC (full streaming protocol).
 
 ## Example datasets in the Jelly format
@@ -23,7 +23,7 @@ Below listed are some example datasets available in the Jelly format. All of the
     - [:octicons-download-24: RDF-star annotated facts from YAGO](https://w3id.org/riverbench/datasets/yago-annotated-facts/1.0.3/files/jelly_full.jelly.gz) ([documentation](https://w3id.org/riverbench/datasets/yago-annotated-facts/1.0.3)) – 2 million triples.
 
 - Small datasets:
-    - [:octicons-download-24: RDF-STaX ontology](https://w3id.org/stax/1.1.3/ontology.jelly) ([documentation](https://w3id.org/stax/1.1.3/ontology)).
+    - [:octicons-download-24: RDF-STaX ontology](https://w3id.org/stax/1.1.4/ontology.jelly) ([documentation](https://w3id.org/stax/1.1.4/ontology)).
     - [:octicons-download-24: RiverBench suite metadata](https://w3id.org/riverbench/v/dev.jelly) ([documentation](https://w3id.org/riverbench/v/dev/documentation/metadata)) – *RiverBench also includes metadata in Jelly for benchmark tasks, datasets, and more.*
 
 You can find more interesting datasets in the Jelly format on the [RiverBench website](https://w3id.org/riverbench/dev/datasets).


### PR DESCRIPTION
The 1.1.4 release of RDF-STaX fixes the issue described here: https://github.com/Jelly-RDF/jelly-jvm/issues/218