### PR TITLE
Add link to protobuf's delimited variant implementation for Python

### DIFF
--- a/docs/specification/serialization.md
+++ b/docs/specification/serialization.md
@@ -602,6 +602,7 @@ The delimiting convention is implemented in Protobuf libraries for:
 
 - C++: [delimited_message_util.cc](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/util/delimited_message_util.cc)
 - Java / Scala: [writeDelimitedTo](https://developers.google.com/protocol-buffers/docs/reference/java/com/google/protobuf/MessageLite#writeDelimitedTo-java.io.OutputStream-) and [parseDelimitedFrom](https://developers.google.com/protocol-buffers/docs/reference/java/com/google/protobuf/Parser#parseDelimitedFrom-java.io.InputStream-)
+- Python: [serialize_length_prefixed and parse_length_prefixed](https://github.com/protocolbuffers/protobuf/blob/v30.2/python/google/protobuf/proto.py)
 
 The JVM (Scala) implementation of Jelly also supports the delimited variant – [see the documentation]({{ jvm_link('user/reactive#byte-streams-delimited-variant') }}).
 


### PR DESCRIPTION
Pinned by tag, because it's quite fresh (3 months?).
C++ implementation is 6+ years old or more. 
Java implementation 7+ or more.