### PR TITLE
Reduce mentions of Scala in the docs

### DIFF
--- a/docs/specification/streaming.md
+++ b/docs/specification/streaming.md
@@ -169,6 +169,6 @@ All security considerations from the [Jelly serialization format specification](
 
 The following implementations of the Jelly gRPC streaming protocol specification are available:
 
-- [Jelly-JVM (Scala) implementation]({{ jvm_link() }})
+- [Jelly-JVM implementation]({{ jvm_link() }})
     - Specification version: {{ proto_version() }}
     - Partial (boilerplate) implementation based on [Apache Pekko gRPC](https://pekko.apache.org/docs/pekko-grpc/current/). Requires the end user to implement their own code for handling the streams.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,6 +1,6 @@
 # Jelly user guide
 
-Jelly uses [Protocol Buffers 3](https://protobuf.dev/programming-guides/proto3/) as the basis of its serialization. You can also use an existing implementation, such as the [JVM (Scala) implementation]({{ jvm_link() }}), or you can quickly [create a new Jelly implementation using code generation](#implementing-jelly). 
+Jelly uses [Protocol Buffers 3](https://protobuf.dev/programming-guides/proto3/) as the basis of its serialization. You can also use an existing implementation, such as the [JVM implementation]({{ jvm_link() }}), or you can quickly [create a new Jelly implementation using code generation](#implementing-jelly). 
 
 ## What can it do?
 
@@ -41,7 +41,7 @@ Go see the **[Jelly-JVM getting started guide for devs]({{ jvm_link('getting-sta
 
 ## How to use it – in detail
 
-To use Jelly you firstly need an implementation of the protocol. There is currently one implementation available: **[Jelly-JVM (Scala)]({{ jvm_link() }})**, which supports [Apache Jena](https://jena.apache.org/), [Eclipse RDF4J](https://rdf4j.org/), and the [Titanium RDF API](https://github.com/filip26/titanium-rdf-api). It also has support for reactive streams (via Pekko Streams) and gRPC.
+To use Jelly you firstly need an implementation of the protocol. There is currently one implementation available: **[Jelly-JVM]({{ jvm_link() }})**, which supports [Apache Jena](https://jena.apache.org/), [Eclipse RDF4J](https://rdf4j.org/), and the [Titanium RDF API](https://github.com/filip26/titanium-rdf-api). It also has support for reactive streams (via Pekko Streams) and gRPC.
 
 The implementation will support several stream types and patterns that you can use. Which stream type you choose depends on your use case (see [stream types](#stream-types) below).
 
@@ -86,7 +86,7 @@ The flat logical stream types ([flat RDF triple stream]({{ stax_link('taxonomy#f
 
 ### Common patterns cookbook
 
-Below you will find some common patterns for using Jelly. These are just examples – you can use Jelly in many other ways. All of the presented patterns are supported in the [Jelly-JVM (Scala) implementation]( {{ jvm_link('user/reactive') }}) with the Reactive Streaming module.
+Below you will find some common patterns for using Jelly. These are just examples – you can use Jelly in many other ways. All of the presented patterns are supported in the [Jelly-JVM implementation]( {{ jvm_link('user/reactive') }}) with the Reactive Streaming module.
 
 #### Flat RDF triple stream – "just a bunch of triples"
 
@@ -298,14 +298,14 @@ You can read more about how this works in the [serialization format specificatio
 
 !!! note
     
-    This section is intended only for those who want to write a new Jelly implementation from scratch. It's much easier to use an existing implementation, such as the [JVM (Scala) implementation]({{ jvm_link() }}).
+    This section is intended only for those who want to write a new Jelly implementation from scratch. It's much easier to use an existing implementation, such as the [JVM implementation]({{ jvm_link() }}).
 
 Implementing Jelly from scratch is greatly simplified by the existing Protobuf and RDF libraries. Essentially, the only thing you'll need to do is to glue them together:
 
 - Find a Protobuf library for your language. You can find a list of official Protobuf implementations [here](https://protobuf.dev/reference/) and a list of community-maintained implementations [here](https://github.com/protocolbuffers/protobuf/blob/main/docs/third_party.md).
 - Use the library to generate the code for the Jelly messages (this usually involves using `protoc`). You can find the Protobuf definitions in the [jelly-protobuf](https://github.com/Jelly-RDF/jelly-protobuf) repository.
 - Find an RDF library for your language. You can find a list of RDF libraries [here](https://github.com/semantalytics/awesome-semantic-web#programming).
-- Implement conversions to and/or from the RDF library's data structures. You can find an example of the conversion code in the [Jelly-JVM (Scala) implementation](https://github.com/Jelly-RDF/jelly-jvm) (`core`, `jena`, and `rdf4j` modules).
+- Implement conversions to and/or from the RDF library's data structures. You can find an example of the conversion code in the [Jelly-JVM implementation](https://github.com/Jelly-RDF/jelly-jvm) (`core`, `jena`, and `rdf4j` modules).
 - In the implementation follow the [specification](specification/index.md) to ensure compatibility.
 
 That's it! You may also want to implement streaming facilities, such as [Reactive Streams](https://www.reactive-streams.org/) in Java/Scala. Implementing the [gRPC publish/subscribe mechanism](specification/streaming.md) follows a very similar procedure – many Protobuf libraries have built-in support for gRPC with code generation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,7 +105,7 @@ nav:
     - Protobuf source: 'specification/protobuf-source.md'
     - File extensions and media types: 'specification/media-type.md'
 
-  - JVM (Scala) implementation: 'https://w3id.org/jelly/jelly-jvm/'
+  - JVM implementation: 'https://w3id.org/jelly/jelly-jvm/'
   - Python implementation: 'https://w3id.org/jelly/pyjelly/'
 
   - Contributing:


### PR DESCRIPTION
Jelly-JVM core is now in pure Java, so we need to update the docs so as not to scare people with Scala :)