### PR TITLE
docs: always install latest version via mise

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -66,7 +66,7 @@
             You can install `jelly-cli` on any platform (including Windows) using [mise](https://mise.jdx.dev/getting-started.html). Simply run:
 
             ```shell
-            mise use -g 'ubi:Jelly-RDF/cli[exe=jelly-cli]'
+            mise use -g 'ubi:Jelly-RDF/cli[exe=jelly-cli]@latest'
             jelly-cli
             ```
 


### PR DESCRIPTION
Otherwise, mise defaults to the version currently installed, and no upgrades are made.