### PR TITLE
Quick start: remove mise @latest option

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -66,7 +66,7 @@
             You can install `jelly-cli` on any platform (including Windows) using [mise](https://mise.jdx.dev/getting-started.html). Simply run:
 
             ```shell
-            mise use -g 'ubi:Jelly-RDF/cli[exe=jelly-cli]@latest'
+            mise use -g 'ubi:Jelly-RDF/cli[exe=jelly-cli]'
             jelly-cli
             ```
 


### PR DESCRIPTION
I was wrong, this is not how mise works. This doesn't help at all. You have to upgrade manually.