### PR TITLE
PY-17: Add conformance tests note

### DIFF
--- a/docs/specification/includes/conformance.md
+++ b/docs/specification/includes/conformance.md
@@ -1,5 +1,10 @@
 Implementations MAY choose to implement only a subset of the following specification. In this case, they SHOULD clearly specify which parts of the specification they implement. In the rest of this specification, the keywords "MUST", "MUST NOT", etc. refer to full (not partial) implementations.
 
+!!! note "**The official Jelly conformance tests determine conformance**"
+    Conformance is checked and determined by running the official Jelly [conformance tests](https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test).  
+    An implementation may claim conformance only if, for its implemented protocol version, it MUST pass all applicable tests.  
+    Claims of partial conformance **MUST** state exactly which test groups were passed and the protocol version.
+
 !!! note
 
     Implementations may in particular choose to not implement features that are not supported on the target platform (e.g., RDF datasets, RDF-star, generalized RDF terms, etc.).


### PR DESCRIPTION
Relates to https://neverblink.youtrack.cloud/issue/PY-17/Add-conformance-tests-note-and-link-to-spec.
Short doc update to add reference to conformance tests specification.