### PR TITLE
Add YATTER to use cases for pyjelly

### DIFF
--- a/docs/conformance/rdf-reports.md
+++ b/docs/conformance/rdf-reports.md
@@ -7,7 +7,7 @@ The information presented here includes:
 - The [**report table**](#report-table), which provides a comparative overview of test outcomes across all submitted implementations.  
 - The [**available reports**](#available-reports) section, which lists implementation metadata (name, version, developer, assertor, and issue date) together with compliance statistics.
 
-Note that implementations are not required to submit all features of Jelly-RDF. In particular, you will find that many implementations do not support:
+Note that implementations are not required to cover all features of Jelly-RDF. In particular, you will find that many implementations do not support:
 
 - The GRAPHS physical type for serialization (to Jelly). The GRAPHS type is considered legacy, and using the QUADS type is recommended instead.
 - Generalized RDF (e.g., triples with literals in subject position). Many RDF libraries do not support this feature.

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -28,6 +28,13 @@
 - **[RDF Stream Taxonomy (RDF-STaX)](https://w3id.org/stax)** uses Jelly for distributing the RDF-STaX ontology and the living literature review of RDF streaming.
     - This is implemented using [jelly-cli](https://github.com/Jelly-RDF/cli). Source code: [GitHub](https://github.com/RDF-STaX/ci-worker).
 
+## [pyjelly]({{ python_link() }})
+
+### Tools and libraries
+
+- **[YATTER](https://github.com/citiususc/yatter)** – a library and CLI tool that translates between YARRRML documents and their corresponding RML or R2RML representations. 
+    - YATTER CLI supports Jelly as one of the input/output formats for RML/R2RML mappings.
+
 ## Example datasets in the Jelly format
 
 Below listed are some example datasets available in the Jelly format. All of these are in the [delimited format](user-guide.md#delimited-vs-non-delimited-jelly). The licenses for these datasets are specified on the linked documentation pages.


### PR DESCRIPTION
A new section has been added for pyjelly in the use cases that lists YATTER support.