### PR TITLE
Add Locorda RDF Jelly conformance report

### DIFF
--- a/docs/conformance/reports/Locorda RDF Jelly.ttl
+++ b/docs/conformance/reports/Locorda RDF Jelly.ttl
@@ -5,7 +5,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <>
-    dc:issued "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+    dc:issued "2026-04-18T13:45:45Z"^^xsd:dateTime ;
     foaf:maker <#assertor> ;
     foaf:primaryTopic <#impl> .
 
@@ -34,7 +34,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/neg_001> .
@@ -43,7 +43,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/neg_002> .
@@ -52,7 +52,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/neg_003> .
@@ -61,7 +61,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/neg_005> .
@@ -70,7 +70,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/neg_006> .
@@ -79,7 +79,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/neg_007> .
@@ -88,7 +88,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/neg_008> .
@@ -97,7 +97,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/neg_010> .
@@ -106,7 +106,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/neg_012> .
@@ -115,7 +115,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/neg_013> .
@@ -124,7 +124,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_001> .
@@ -133,7 +133,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_002> .
@@ -142,7 +142,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_003> .
@@ -151,7 +151,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_004> .
@@ -160,7 +160,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_005> .
@@ -169,7 +169,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_006> .
@@ -178,7 +178,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_007> .
@@ -187,7 +187,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_008> .
@@ -196,7 +196,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_009> .
@@ -205,7 +205,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_011> .
@@ -214,7 +214,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_012> .
@@ -223,7 +223,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_013> .
@@ -232,7 +232,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_014> .
@@ -241,7 +241,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_015> .
@@ -250,7 +250,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_016> .
@@ -259,7 +259,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_017> .
@@ -268,7 +268,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_018> .
@@ -277,7 +277,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/neg_001> .
@@ -286,7 +286,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/neg_002> .
@@ -295,7 +295,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/pos_001> .
@@ -304,7 +304,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/pos_002> .
@@ -313,7 +313,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/pos_003> .
@@ -322,7 +322,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/pos_004> .
@@ -331,7 +331,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/pos_005> .
@@ -340,7 +340,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/pos_006> .
@@ -349,7 +349,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/pos_007> .
@@ -358,7 +358,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/pos_008> .
@@ -367,7 +367,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/pos_009> .
@@ -376,7 +376,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/pos_010> .
@@ -385,7 +385,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/pos_011> .
@@ -394,7 +394,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1/neg_001> .
@@ -403,7 +403,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1/neg_002> .
@@ -412,7 +412,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1/neg_003> .
@@ -421,7 +421,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1/pos_001> .
@@ -430,7 +430,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1/pos_002> .
@@ -439,7 +439,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1/pos_003> .
@@ -448,7 +448,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1/pos_004> .
@@ -457,7 +457,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1/pos_005> .
@@ -466,7 +466,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1/pos_006> .
@@ -475,7 +475,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1/pos_007> .
@@ -484,7 +484,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1/pos_008> .
@@ -493,7 +493,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1_generalized/pos_001> .
@@ -502,7 +502,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1_generalized/pos_002> .
@@ -511,7 +511,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1_generalized/pos_003> .
@@ -520,7 +520,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1_generalized/pos_004> .
@@ -529,7 +529,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1_generalized/pos_005> .
@@ -538,7 +538,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1_generalized/pos_001> .
@@ -547,7 +547,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1_generalized/pos_002> .
@@ -556,7 +556,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1_generalized/pos_003> .
@@ -565,7 +565,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1_generalized/pos_004> .
@@ -574,7 +574,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1_generalized/pos_005> .
@@ -583,7 +583,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star/neg_001> .
@@ -592,7 +592,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star/neg_002> .
@@ -601,7 +601,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star/neg_003> .
@@ -610,7 +610,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star/pos_001> .
@@ -619,7 +619,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star/pos_002> .
@@ -628,7 +628,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star/pos_003> .
@@ -637,7 +637,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star/pos_004> .
@@ -646,7 +646,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star/pos_005> .
@@ -655,7 +655,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star/pos_006> .
@@ -664,7 +664,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star/pos_007> .
@@ -673,7 +673,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star/pos_008> .
@@ -682,7 +682,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star/neg_001> .
@@ -691,7 +691,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star/neg_002> .
@@ -700,7 +700,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star/neg_003> .
@@ -709,7 +709,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star/pos_001> .
@@ -718,7 +718,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star/pos_002> .
@@ -727,7 +727,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star/pos_003> .
@@ -736,7 +736,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star/pos_004> .
@@ -745,7 +745,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star/pos_005> .
@@ -754,7 +754,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star/pos_006> .
@@ -763,7 +763,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star/pos_007> .
@@ -772,7 +772,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_star/neg_001> .
@@ -781,7 +781,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_star/neg_002> .
@@ -790,7 +790,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_star/neg_003> .
@@ -799,7 +799,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_star/pos_001> .
@@ -808,7 +808,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_star/pos_002> .
@@ -817,7 +817,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_star/pos_003> .
@@ -826,7 +826,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_star/pos_004> .
@@ -835,7 +835,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_star/pos_005> .
@@ -844,7 +844,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_star/pos_006> .
@@ -853,7 +853,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_star/pos_007> .
@@ -862,7 +862,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star_generalized/neg_001> .
@@ -871,7 +871,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star_generalized/neg_002> .
@@ -880,7 +880,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star_generalized/neg_003> .
@@ -889,7 +889,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star_generalized/pos_001> .
@@ -898,7 +898,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star_generalized/pos_002> .
@@ -907,7 +907,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star_generalized/pos_003> .
@@ -916,7 +916,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star_generalized/pos_004> .
@@ -925,7 +925,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star_generalized/pos_005> .
@@ -934,7 +934,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star_generalized/pos_006> .
@@ -943,7 +943,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star_generalized/neg_001> .
@@ -952,7 +952,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star_generalized/neg_002> .
@@ -961,7 +961,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star_generalized/neg_003> .
@@ -970,7 +970,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star_generalized/pos_001> .
@@ -979,7 +979,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star_generalized/pos_002> .
@@ -988,7 +988,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star_generalized/pos_003> .
@@ -997,7 +997,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star_generalized/pos_004> .
@@ -1006,7 +1006,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star_generalized/pos_005> .
@@ -1015,7 +1015,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star_generalized/pos_006> .
@@ -1024,8 +1024,8 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
-            earl:outcome earl:inapplicable ] ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/neg_001> .
 
@@ -1033,8 +1033,8 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
-            earl:outcome earl:inapplicable ] ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/neg_002> .
 
@@ -1042,7 +1042,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_001> .
@@ -1051,7 +1051,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_002> .
@@ -1060,7 +1060,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_003> .
@@ -1069,7 +1069,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_004> .
@@ -1078,7 +1078,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_005> .
@@ -1087,7 +1087,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_006> .
@@ -1096,7 +1096,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_007> .
@@ -1105,7 +1105,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_008> .
@@ -1114,7 +1114,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_009> .
@@ -1123,7 +1123,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_010> .
@@ -1132,7 +1132,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_011> .
@@ -1141,7 +1141,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_012> .
@@ -1150,7 +1150,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_013> .
@@ -1159,7 +1159,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_014> .
@@ -1168,7 +1168,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_015> .
@@ -1177,7 +1177,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_016> .
@@ -1186,7 +1186,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_1_1/pos_001> .
@@ -1195,7 +1195,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_1_1/pos_002> .
@@ -1204,7 +1204,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_1_1/pos_003> .
@@ -1213,7 +1213,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_1_1/pos_004> .
@@ -1222,7 +1222,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_1_1/pos_005> .
@@ -1231,7 +1231,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_1_1/pos_006> .
@@ -1240,7 +1240,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_1_1/pos_001> .
@@ -1249,7 +1249,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_1_1/pos_002> .
@@ -1258,7 +1258,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_1_1/pos_003> .
@@ -1267,7 +1267,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_1_1/pos_004> .
@@ -1276,7 +1276,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_1_1/pos_005> .
@@ -1285,7 +1285,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_1_1/pos_006> .
@@ -1294,7 +1294,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_1_1/pos_007> .
@@ -1303,7 +1303,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_1_1/pos_008> .
@@ -1312,7 +1312,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:passed ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_1_1/pos_009> .
@@ -1321,7 +1321,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1_generalized/pos_001> .
@@ -1330,7 +1330,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1_generalized/pos_002> .
@@ -1339,7 +1339,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1_generalized/pos_003> .
@@ -1348,7 +1348,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1_generalized/pos_004> .
@@ -1357,7 +1357,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1_generalized/pos_005> .
@@ -1366,7 +1366,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_1_1_generalized/pos_001> .
@@ -1375,7 +1375,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_1_1_generalized/pos_002> .
@@ -1384,7 +1384,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_1_1_generalized/pos_003> .
@@ -1393,7 +1393,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_1_1_generalized/pos_004> .
@@ -1402,7 +1402,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_1_1_generalized/pos_005> .
@@ -1411,7 +1411,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star/pos_001> .
@@ -1420,7 +1420,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star/pos_002> .
@@ -1429,7 +1429,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star/pos_003> .
@@ -1438,7 +1438,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star/pos_004> .
@@ -1447,7 +1447,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star/pos_005> .
@@ -1456,7 +1456,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star/pos_006> .
@@ -1465,7 +1465,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star/pos_007> .
@@ -1474,7 +1474,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star/pos_008> .
@@ -1483,7 +1483,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star/pos_001> .
@@ -1492,7 +1492,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star/pos_002> .
@@ -1501,7 +1501,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star/pos_003> .
@@ -1510,7 +1510,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star/pos_004> .
@@ -1519,7 +1519,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star/pos_005> .
@@ -1528,7 +1528,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star/pos_006> .
@@ -1537,7 +1537,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star/pos_007> .
@@ -1546,7 +1546,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_star/pos_001> .
@@ -1555,7 +1555,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_star/pos_002> .
@@ -1564,7 +1564,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_star/pos_003> .
@@ -1573,7 +1573,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_star/pos_004> .
@@ -1582,7 +1582,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_star/pos_005> .
@@ -1591,7 +1591,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_star/pos_006> .
@@ -1600,7 +1600,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_star/pos_007> .
@@ -1609,7 +1609,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star_generalized/pos_001> .
@@ -1618,7 +1618,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star_generalized/pos_002> .
@@ -1627,7 +1627,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star_generalized/pos_003> .
@@ -1636,7 +1636,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star_generalized/pos_004> .
@@ -1645,7 +1645,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star_generalized/pos_005> .
@@ -1654,7 +1654,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star_generalized/pos_006> .
@@ -1663,7 +1663,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star_generalized/pos_001> .
@@ -1672,7 +1672,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star_generalized/pos_002> .
@@ -1681,7 +1681,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star_generalized/pos_003> .
@@ -1690,7 +1690,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star_generalized/pos_004> .
@@ -1699,7 +1699,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star_generalized/pos_005> .
@@ -1708,7 +1708,7 @@
     earl:assertedBy <#assertor> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            dc:date "2026-04-18T13:45:45Z"^^xsd:dateTime ;
             earl:outcome earl:inapplicable ] ;
     earl:subject <#impl> ;
     earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star_generalized/pos_006> .

--- a/docs/conformance/reports/Locorda RDF Jelly.ttl
+++ b/docs/conformance/reports/Locorda RDF Jelly.ttl
@@ -1,0 +1,1715 @@
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix earl: <http://www.w3.org/ns/earl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+    dc:issued "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+    foaf:maker <#assertor> ;
+    foaf:primaryTopic <#impl> .
+
+<#developer> a foaf:Group ;
+    foaf:homepage <https://github.com/locorda/rdf> ;
+    foaf:name "Locorda RDF contributors" .
+
+<#assertor> a earl:Assertor,
+        earl:Software ;
+    foaf:homepage <https://github.com/locorda/rdf/tree/main/packages/locorda_rdf_jelly/tool/generate_earl_report.dart> ;
+    foaf:name "Locorda RDF Jelly EARL report generator" .
+
+<#impl> a doap:Project,
+        doap:Software,
+        doap:TestSubject ;
+    doap:description "Locorda RDF Jelly – Jelly RDF binary serialization codec"@en ;
+    doap:developer <#developer> ;
+    doap:homepage <https://locorda.dev/rdf/jelly> ;
+    doap:name "Locorda RDF Jelly" ;
+    doap:programming-language "Dart" ;
+    doap:release [ dc:created "2026-04-18"^^xsd:date ;
+            doap:name "Locorda RDF Jelly" ;
+            doap:revision "0.12.0" ] .
+
+<#rdf_from_jelly_triples_rdf_1_1_neg_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/neg_001> .
+
+<#rdf_from_jelly_triples_rdf_1_1_neg_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/neg_002> .
+
+<#rdf_from_jelly_triples_rdf_1_1_neg_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/neg_003> .
+
+<#rdf_from_jelly_triples_rdf_1_1_neg_005> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/neg_005> .
+
+<#rdf_from_jelly_triples_rdf_1_1_neg_006> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/neg_006> .
+
+<#rdf_from_jelly_triples_rdf_1_1_neg_007> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/neg_007> .
+
+<#rdf_from_jelly_triples_rdf_1_1_neg_008> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/neg_008> .
+
+<#rdf_from_jelly_triples_rdf_1_1_neg_010> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/neg_010> .
+
+<#rdf_from_jelly_triples_rdf_1_1_neg_012> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/neg_012> .
+
+<#rdf_from_jelly_triples_rdf_1_1_neg_013> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/neg_013> .
+
+<#rdf_from_jelly_triples_rdf_1_1_pos_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_001> .
+
+<#rdf_from_jelly_triples_rdf_1_1_pos_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_002> .
+
+<#rdf_from_jelly_triples_rdf_1_1_pos_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_003> .
+
+<#rdf_from_jelly_triples_rdf_1_1_pos_004> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_004> .
+
+<#rdf_from_jelly_triples_rdf_1_1_pos_005> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_005> .
+
+<#rdf_from_jelly_triples_rdf_1_1_pos_006> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_006> .
+
+<#rdf_from_jelly_triples_rdf_1_1_pos_007> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_007> .
+
+<#rdf_from_jelly_triples_rdf_1_1_pos_008> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_008> .
+
+<#rdf_from_jelly_triples_rdf_1_1_pos_009> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_009> .
+
+<#rdf_from_jelly_triples_rdf_1_1_pos_011> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_011> .
+
+<#rdf_from_jelly_triples_rdf_1_1_pos_012> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_012> .
+
+<#rdf_from_jelly_triples_rdf_1_1_pos_013> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_013> .
+
+<#rdf_from_jelly_triples_rdf_1_1_pos_014> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_014> .
+
+<#rdf_from_jelly_triples_rdf_1_1_pos_015> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_015> .
+
+<#rdf_from_jelly_triples_rdf_1_1_pos_016> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_016> .
+
+<#rdf_from_jelly_triples_rdf_1_1_pos_017> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_017> .
+
+<#rdf_from_jelly_triples_rdf_1_1_pos_018> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1/pos_018> .
+
+<#rdf_from_jelly_graphs_rdf_1_1_neg_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/neg_001> .
+
+<#rdf_from_jelly_graphs_rdf_1_1_neg_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/neg_002> .
+
+<#rdf_from_jelly_graphs_rdf_1_1_pos_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/pos_001> .
+
+<#rdf_from_jelly_graphs_rdf_1_1_pos_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/pos_002> .
+
+<#rdf_from_jelly_graphs_rdf_1_1_pos_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/pos_003> .
+
+<#rdf_from_jelly_graphs_rdf_1_1_pos_004> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/pos_004> .
+
+<#rdf_from_jelly_graphs_rdf_1_1_pos_005> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/pos_005> .
+
+<#rdf_from_jelly_graphs_rdf_1_1_pos_006> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/pos_006> .
+
+<#rdf_from_jelly_graphs_rdf_1_1_pos_007> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/pos_007> .
+
+<#rdf_from_jelly_graphs_rdf_1_1_pos_008> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/pos_008> .
+
+<#rdf_from_jelly_graphs_rdf_1_1_pos_009> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/pos_009> .
+
+<#rdf_from_jelly_graphs_rdf_1_1_pos_010> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/pos_010> .
+
+<#rdf_from_jelly_graphs_rdf_1_1_pos_011> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_1_1/pos_011> .
+
+<#rdf_from_jelly_quads_rdf_1_1_neg_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1/neg_001> .
+
+<#rdf_from_jelly_quads_rdf_1_1_neg_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1/neg_002> .
+
+<#rdf_from_jelly_quads_rdf_1_1_neg_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1/neg_003> .
+
+<#rdf_from_jelly_quads_rdf_1_1_pos_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1/pos_001> .
+
+<#rdf_from_jelly_quads_rdf_1_1_pos_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1/pos_002> .
+
+<#rdf_from_jelly_quads_rdf_1_1_pos_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1/pos_003> .
+
+<#rdf_from_jelly_quads_rdf_1_1_pos_004> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1/pos_004> .
+
+<#rdf_from_jelly_quads_rdf_1_1_pos_005> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1/pos_005> .
+
+<#rdf_from_jelly_quads_rdf_1_1_pos_006> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1/pos_006> .
+
+<#rdf_from_jelly_quads_rdf_1_1_pos_007> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1/pos_007> .
+
+<#rdf_from_jelly_quads_rdf_1_1_pos_008> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1/pos_008> .
+
+<#rdf_from_jelly_triples_rdf_1_1_generalized_pos_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1_generalized/pos_001> .
+
+<#rdf_from_jelly_triples_rdf_1_1_generalized_pos_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1_generalized/pos_002> .
+
+<#rdf_from_jelly_triples_rdf_1_1_generalized_pos_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1_generalized/pos_003> .
+
+<#rdf_from_jelly_triples_rdf_1_1_generalized_pos_004> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1_generalized/pos_004> .
+
+<#rdf_from_jelly_triples_rdf_1_1_generalized_pos_005> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_1_1_generalized/pos_005> .
+
+<#rdf_from_jelly_quads_rdf_1_1_generalized_pos_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1_generalized/pos_001> .
+
+<#rdf_from_jelly_quads_rdf_1_1_generalized_pos_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1_generalized/pos_002> .
+
+<#rdf_from_jelly_quads_rdf_1_1_generalized_pos_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1_generalized/pos_003> .
+
+<#rdf_from_jelly_quads_rdf_1_1_generalized_pos_004> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1_generalized/pos_004> .
+
+<#rdf_from_jelly_quads_rdf_1_1_generalized_pos_005> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_1_1_generalized/pos_005> .
+
+<#rdf_from_jelly_triples_rdf_star_neg_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star/neg_001> .
+
+<#rdf_from_jelly_triples_rdf_star_neg_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star/neg_002> .
+
+<#rdf_from_jelly_triples_rdf_star_neg_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star/neg_003> .
+
+<#rdf_from_jelly_triples_rdf_star_pos_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star/pos_001> .
+
+<#rdf_from_jelly_triples_rdf_star_pos_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star/pos_002> .
+
+<#rdf_from_jelly_triples_rdf_star_pos_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star/pos_003> .
+
+<#rdf_from_jelly_triples_rdf_star_pos_004> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star/pos_004> .
+
+<#rdf_from_jelly_triples_rdf_star_pos_005> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star/pos_005> .
+
+<#rdf_from_jelly_triples_rdf_star_pos_006> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star/pos_006> .
+
+<#rdf_from_jelly_triples_rdf_star_pos_007> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star/pos_007> .
+
+<#rdf_from_jelly_triples_rdf_star_pos_008> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star/pos_008> .
+
+<#rdf_from_jelly_quads_rdf_star_neg_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star/neg_001> .
+
+<#rdf_from_jelly_quads_rdf_star_neg_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star/neg_002> .
+
+<#rdf_from_jelly_quads_rdf_star_neg_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star/neg_003> .
+
+<#rdf_from_jelly_quads_rdf_star_pos_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star/pos_001> .
+
+<#rdf_from_jelly_quads_rdf_star_pos_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star/pos_002> .
+
+<#rdf_from_jelly_quads_rdf_star_pos_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star/pos_003> .
+
+<#rdf_from_jelly_quads_rdf_star_pos_004> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star/pos_004> .
+
+<#rdf_from_jelly_quads_rdf_star_pos_005> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star/pos_005> .
+
+<#rdf_from_jelly_quads_rdf_star_pos_006> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star/pos_006> .
+
+<#rdf_from_jelly_quads_rdf_star_pos_007> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star/pos_007> .
+
+<#rdf_from_jelly_graphs_rdf_star_neg_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_star/neg_001> .
+
+<#rdf_from_jelly_graphs_rdf_star_neg_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_star/neg_002> .
+
+<#rdf_from_jelly_graphs_rdf_star_neg_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_star/neg_003> .
+
+<#rdf_from_jelly_graphs_rdf_star_pos_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_star/pos_001> .
+
+<#rdf_from_jelly_graphs_rdf_star_pos_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_star/pos_002> .
+
+<#rdf_from_jelly_graphs_rdf_star_pos_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_star/pos_003> .
+
+<#rdf_from_jelly_graphs_rdf_star_pos_004> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_star/pos_004> .
+
+<#rdf_from_jelly_graphs_rdf_star_pos_005> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_star/pos_005> .
+
+<#rdf_from_jelly_graphs_rdf_star_pos_006> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_star/pos_006> .
+
+<#rdf_from_jelly_graphs_rdf_star_pos_007> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/graphs_rdf_star/pos_007> .
+
+<#rdf_from_jelly_quads_rdf_star_generalized_neg_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star_generalized/neg_001> .
+
+<#rdf_from_jelly_quads_rdf_star_generalized_neg_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star_generalized/neg_002> .
+
+<#rdf_from_jelly_quads_rdf_star_generalized_neg_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star_generalized/neg_003> .
+
+<#rdf_from_jelly_quads_rdf_star_generalized_pos_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star_generalized/pos_001> .
+
+<#rdf_from_jelly_quads_rdf_star_generalized_pos_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star_generalized/pos_002> .
+
+<#rdf_from_jelly_quads_rdf_star_generalized_pos_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star_generalized/pos_003> .
+
+<#rdf_from_jelly_quads_rdf_star_generalized_pos_004> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star_generalized/pos_004> .
+
+<#rdf_from_jelly_quads_rdf_star_generalized_pos_005> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star_generalized/pos_005> .
+
+<#rdf_from_jelly_quads_rdf_star_generalized_pos_006> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/quads_rdf_star_generalized/pos_006> .
+
+<#rdf_from_jelly_triples_rdf_star_generalized_neg_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star_generalized/neg_001> .
+
+<#rdf_from_jelly_triples_rdf_star_generalized_neg_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star_generalized/neg_002> .
+
+<#rdf_from_jelly_triples_rdf_star_generalized_neg_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star_generalized/neg_003> .
+
+<#rdf_from_jelly_triples_rdf_star_generalized_pos_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star_generalized/pos_001> .
+
+<#rdf_from_jelly_triples_rdf_star_generalized_pos_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star_generalized/pos_002> .
+
+<#rdf_from_jelly_triples_rdf_star_generalized_pos_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star_generalized/pos_003> .
+
+<#rdf_from_jelly_triples_rdf_star_generalized_pos_004> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star_generalized/pos_004> .
+
+<#rdf_from_jelly_triples_rdf_star_generalized_pos_005> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star_generalized/pos_005> .
+
+<#rdf_from_jelly_triples_rdf_star_generalized_pos_006> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/from_jelly/triples_rdf_star_generalized/pos_006> .
+
+<#rdf_to_jelly_triples_rdf_1_1_neg_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/neg_001> .
+
+<#rdf_to_jelly_triples_rdf_1_1_neg_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/neg_002> .
+
+<#rdf_to_jelly_triples_rdf_1_1_pos_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_001> .
+
+<#rdf_to_jelly_triples_rdf_1_1_pos_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_002> .
+
+<#rdf_to_jelly_triples_rdf_1_1_pos_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_003> .
+
+<#rdf_to_jelly_triples_rdf_1_1_pos_004> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_004> .
+
+<#rdf_to_jelly_triples_rdf_1_1_pos_005> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_005> .
+
+<#rdf_to_jelly_triples_rdf_1_1_pos_006> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_006> .
+
+<#rdf_to_jelly_triples_rdf_1_1_pos_007> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_007> .
+
+<#rdf_to_jelly_triples_rdf_1_1_pos_008> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_008> .
+
+<#rdf_to_jelly_triples_rdf_1_1_pos_009> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_009> .
+
+<#rdf_to_jelly_triples_rdf_1_1_pos_010> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_010> .
+
+<#rdf_to_jelly_triples_rdf_1_1_pos_011> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_011> .
+
+<#rdf_to_jelly_triples_rdf_1_1_pos_012> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_012> .
+
+<#rdf_to_jelly_triples_rdf_1_1_pos_013> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_013> .
+
+<#rdf_to_jelly_triples_rdf_1_1_pos_014> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_014> .
+
+<#rdf_to_jelly_triples_rdf_1_1_pos_015> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_015> .
+
+<#rdf_to_jelly_triples_rdf_1_1_pos_016> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1/pos_016> .
+
+<#rdf_to_jelly_quads_rdf_1_1_pos_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_1_1/pos_001> .
+
+<#rdf_to_jelly_quads_rdf_1_1_pos_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_1_1/pos_002> .
+
+<#rdf_to_jelly_quads_rdf_1_1_pos_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_1_1/pos_003> .
+
+<#rdf_to_jelly_quads_rdf_1_1_pos_004> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_1_1/pos_004> .
+
+<#rdf_to_jelly_quads_rdf_1_1_pos_005> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_1_1/pos_005> .
+
+<#rdf_to_jelly_quads_rdf_1_1_pos_006> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_1_1/pos_006> .
+
+<#rdf_to_jelly_graphs_rdf_1_1_pos_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_1_1/pos_001> .
+
+<#rdf_to_jelly_graphs_rdf_1_1_pos_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_1_1/pos_002> .
+
+<#rdf_to_jelly_graphs_rdf_1_1_pos_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_1_1/pos_003> .
+
+<#rdf_to_jelly_graphs_rdf_1_1_pos_004> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_1_1/pos_004> .
+
+<#rdf_to_jelly_graphs_rdf_1_1_pos_005> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_1_1/pos_005> .
+
+<#rdf_to_jelly_graphs_rdf_1_1_pos_006> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_1_1/pos_006> .
+
+<#rdf_to_jelly_graphs_rdf_1_1_pos_007> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_1_1/pos_007> .
+
+<#rdf_to_jelly_graphs_rdf_1_1_pos_008> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_1_1/pos_008> .
+
+<#rdf_to_jelly_graphs_rdf_1_1_pos_009> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:passed ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_1_1/pos_009> .
+
+<#rdf_to_jelly_triples_rdf_1_1_generalized_pos_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1_generalized/pos_001> .
+
+<#rdf_to_jelly_triples_rdf_1_1_generalized_pos_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1_generalized/pos_002> .
+
+<#rdf_to_jelly_triples_rdf_1_1_generalized_pos_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1_generalized/pos_003> .
+
+<#rdf_to_jelly_triples_rdf_1_1_generalized_pos_004> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1_generalized/pos_004> .
+
+<#rdf_to_jelly_triples_rdf_1_1_generalized_pos_005> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_1_1_generalized/pos_005> .
+
+<#rdf_to_jelly_quads_rdf_1_1_generalized_pos_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_1_1_generalized/pos_001> .
+
+<#rdf_to_jelly_quads_rdf_1_1_generalized_pos_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_1_1_generalized/pos_002> .
+
+<#rdf_to_jelly_quads_rdf_1_1_generalized_pos_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_1_1_generalized/pos_003> .
+
+<#rdf_to_jelly_quads_rdf_1_1_generalized_pos_004> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_1_1_generalized/pos_004> .
+
+<#rdf_to_jelly_quads_rdf_1_1_generalized_pos_005> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_1_1_generalized/pos_005> .
+
+<#rdf_to_jelly_triples_rdf_star_pos_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star/pos_001> .
+
+<#rdf_to_jelly_triples_rdf_star_pos_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star/pos_002> .
+
+<#rdf_to_jelly_triples_rdf_star_pos_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star/pos_003> .
+
+<#rdf_to_jelly_triples_rdf_star_pos_004> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star/pos_004> .
+
+<#rdf_to_jelly_triples_rdf_star_pos_005> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star/pos_005> .
+
+<#rdf_to_jelly_triples_rdf_star_pos_006> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star/pos_006> .
+
+<#rdf_to_jelly_triples_rdf_star_pos_007> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star/pos_007> .
+
+<#rdf_to_jelly_triples_rdf_star_pos_008> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star/pos_008> .
+
+<#rdf_to_jelly_quads_rdf_star_pos_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star/pos_001> .
+
+<#rdf_to_jelly_quads_rdf_star_pos_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star/pos_002> .
+
+<#rdf_to_jelly_quads_rdf_star_pos_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star/pos_003> .
+
+<#rdf_to_jelly_quads_rdf_star_pos_004> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star/pos_004> .
+
+<#rdf_to_jelly_quads_rdf_star_pos_005> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star/pos_005> .
+
+<#rdf_to_jelly_quads_rdf_star_pos_006> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star/pos_006> .
+
+<#rdf_to_jelly_quads_rdf_star_pos_007> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star/pos_007> .
+
+<#rdf_to_jelly_graphs_rdf_star_pos_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_star/pos_001> .
+
+<#rdf_to_jelly_graphs_rdf_star_pos_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_star/pos_002> .
+
+<#rdf_to_jelly_graphs_rdf_star_pos_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_star/pos_003> .
+
+<#rdf_to_jelly_graphs_rdf_star_pos_004> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_star/pos_004> .
+
+<#rdf_to_jelly_graphs_rdf_star_pos_005> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_star/pos_005> .
+
+<#rdf_to_jelly_graphs_rdf_star_pos_006> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_star/pos_006> .
+
+<#rdf_to_jelly_graphs_rdf_star_pos_007> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/graphs_rdf_star/pos_007> .
+
+<#rdf_to_jelly_quads_rdf_star_generalized_pos_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star_generalized/pos_001> .
+
+<#rdf_to_jelly_quads_rdf_star_generalized_pos_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star_generalized/pos_002> .
+
+<#rdf_to_jelly_quads_rdf_star_generalized_pos_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star_generalized/pos_003> .
+
+<#rdf_to_jelly_quads_rdf_star_generalized_pos_004> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star_generalized/pos_004> .
+
+<#rdf_to_jelly_quads_rdf_star_generalized_pos_005> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star_generalized/pos_005> .
+
+<#rdf_to_jelly_quads_rdf_star_generalized_pos_006> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/quads_rdf_star_generalized/pos_006> .
+
+<#rdf_to_jelly_triples_rdf_star_generalized_pos_001> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star_generalized/pos_001> .
+
+<#rdf_to_jelly_triples_rdf_star_generalized_pos_002> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star_generalized/pos_002> .
+
+<#rdf_to_jelly_triples_rdf_star_generalized_pos_003> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star_generalized/pos_003> .
+
+<#rdf_to_jelly_triples_rdf_star_generalized_pos_004> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star_generalized/pos_004> .
+
+<#rdf_to_jelly_triples_rdf_star_generalized_pos_005> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star_generalized/pos_005> .
+
+<#rdf_to_jelly_triples_rdf_star_generalized_pos_006> a earl:Assertion ;
+    earl:assertedBy <#assertor> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            dc:date "2026-04-18T11:01:47Z"^^xsd:dateTime ;
+            earl:outcome earl:inapplicable ] ;
+    earl:subject <#impl> ;
+    earl:test <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/rdf/to_jelly/triples_rdf_star_generalized/pos_006> .
+


### PR DESCRIPTION
Adds an EARL 1.0 conformance report for **Locorda RDF Jelly** (Dart implementation of the Jelly RDF binary serialization codec), version 0.12.0.

The report was generated automatically by the [Locorda RDF Jelly EARL report generator](https://github.com/locorda/rdf/tree/main/packages/locorda_rdf_jelly/tool/generate_earl_report.dart) on 2026-04-18 and covers the Jelly RDF test suite.