### PR TITLE
Add Dart implementation, reorg docs

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -35,6 +35,11 @@ Best way to start is to hop on the [Jelly Discord chat](https://discord.gg/A8sN5
 - [GitHub repository](https://github.com/Jelly-RDF/jelly_rs)
 - [Issue tracker](https://github.com/Jelly-RDF/jelly_rs/issues)
 
+### Locorda (Dart, *unofficial, experimental*)
+
+- [Website](https://locorda.dev/rdf/jelly/)
+- [GitHub repository](https://github.com/locorda/rdf)
+
 ## New implementations and integrations
 
 Would you like to integrate Jelly into your project or implement it in a new language? You are welcome to do so! Check out [our tips for implementing Jelly in a new language](../user-guide.md#implementing-jelly). You can also join the [Jelly Discord chat](https://discord.gg/A8sN5XwVa5) to discuss your plans and get help. Or, if you have a commercial project in mind, you can [contact NeverBlink](mailto:piotr@neverblink) for professional support.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@
 
     [:octicons-arrow-right-24: pyjelly]({{ python_link() }})
 
-    [:octicons-arrow-right-24: *More implementations*](user-guide.md)
+    [:octicons-arrow-right-24: More implementations](user-guide.md)
 
 -   :fontawesome-solid-angles-right:{ .lg .middle } __End-to-end streaming__
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,8 @@
 
     [:octicons-arrow-right-24: pyjelly]({{ python_link() }})
 
+    [:octicons-arrow-right-24: *More implementations*](user-guide.md)
+
 -   :fontawesome-solid-angles-right:{ .lg .middle } __End-to-end streaming__
 
     ---
@@ -269,6 +271,8 @@ Community support is available on the **[Jelly Discord chat](https://discord.gg/
     - [Rust implementation](https://github.com/Jelly-RDF/jelly_rs) *(experimental)*
     - [Command-line utility (`jelly-cli`)](https://github.com/Jelly-RDF/cli)
     - [Website](https://github.com/Jelly-RDF/jelly-rdf.github.io)
+- **Community projects:**
+    - [Implementation in Dart](https://locorda.dev/rdf/jelly/)
 - **[Licensing and citation](licensing/index.md)**
 
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -5,6 +5,7 @@ To use Jelly, pick an implementation that matches your tech stack:
 - **[Jelly-JVM]({{ jvm_link() }})** – written in Java, integrated with Apache Jena, RDF4J, Titanium, and Neo4j.
 - **[pyjelly]({{ python_link() }})** – written in Python, integrated with RDFLib. Can also be used without RDFLib.
 - **[jelly_rs](https://github.com/Jelly-RDF/jelly_rs)** *(experimental)* – written in Rust, integrated with Sophia.
+- **[Locorda](https://locorda.dev/rdf/jelly/)** *(unofficial, community-led)* – written in Dart.
 - **[jelly-cli](https://github.com/Jelly-RDF/cli)** – command-line tool, works on Windows, macOS, and Linux.
 
 You can also [create your own implementation](#implementing-jelly). Because Jelly is built on top of [Protocol Buffers](https://protobuf.dev/), you can generate most of the code automatically in any popular programming language.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,13 @@ extra:
 nav:
   - Home: 'index.md'
   - User guide: 'user-guide.md'
+
+  - Implementations:
+    - Java / JVM: 'https://w3id.org/jelly/jelly-jvm/'
+    - Python: 'https://w3id.org/jelly/pyjelly/'
+    - Rust (experimental): 'https://github.com/Jelly-RDF/jelly_rs'
+    - Dart (community): 'https://locorda.dev/rdf/jelly/'
+
   - Performance: 
     - 'performance/index.md'
     - RDF4J benchmarks: 'performance/rdf4j.md'
@@ -112,9 +119,7 @@ nav:
     - Reporting conformance: 'conformance/reporting-conformance.md'
     - Jelly-RDF test cases: 'conformance/rdf-test-cases.md'
     - Jelly-RDF conformance reports: 'conformance/rdf-reports.md'
-  - JVM implementation: 'https://w3id.org/jelly/jelly-jvm/'
-  - Python implementation: 'https://w3id.org/jelly/pyjelly/'
-
+    
   - Contributing:
     - 'contributing/index.md'
     - Code of conduct: 'contributing/code_of_conduct.md'


### PR DESCRIPTION
Follow-up of #101

I tried to make it easier to find all implementations, of which we have now 4. A fifth one in maplib is under construction: https://github.com/DataTreehouse/maplib/pull/46